### PR TITLE
feat(auth): use HTTP-only cookie for JWT & hide password

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -11,6 +11,16 @@ const signToken = (id) => {
 
 const createSendToken = (user, statusCode, res) => {
   const token = signToken(user._id);
+  const cookieOptions = {
+    expires: new Date(
+      Date.now() + process.env.JWT_COOKIE_EXPIRES_IN * 24 * 60 * 60 * 1000,
+    ),
+    httpOnly: true,
+  };
+  res.cookie('jwt', token, cookieOptions);
+
+  // Remove password from output
+  user.password = undefined;
 
   res.status(statusCode).json({
     status: 'success',


### PR DESCRIPTION
This PR enhances the authentication response by securely storing the JWT in an HTTP-only cookie instead of returning it solely in the response body. This approach improves security by mitigating XSS vulnerabilities while ensuring seamless authentication for subsequent requests.