### PR TITLE
feat: add rate limiting to restrict excessive API requests per IP

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const express = require('express');
 // const { request } = require('http');
 const morgan = require('morgan');
 // const exp = require('constants');
+const rateLimit = require('express-rate-limit');
 
 const tourRouter = require('./routes/tourRoutes');
 const userRouter = require('./routes/userRoutes');
@@ -15,6 +16,14 @@ const app = express();
 if (process.env.NODE_ENV === 'development') {
   app.use(morgan('dev'));
 }
+
+const limiter = rateLimit({
+  max: 100,
+  windowMs: 60 * 60 * 1000,
+  message: 'Too many requests from this IP, please try again in an hour!',
+});
+app.use('/api', limiter);
+
 app.use(express.json());
 app.use(express.static(`${__dirname}/public`));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.2",
         "express": "^4.21.1",
+        "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^5.13.22",
         "morgan": "^1.10.0",
@@ -1854,6 +1855,20 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/external-editor": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.2",
     "express": "^4.21.1",
+    "express-rate-limit": "^7.5.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^5.13.22",
     "morgan": "^1.10.0",


### PR DESCRIPTION
This branch introduces a global rate limiting middleware to enhance API security and prevent excessive requests. 

By implementing `express-rate-limit`, the API now restricts each IP to a maximum of 100 requests per hour. If the limit is exceeded, the server responds with a `Too Many Requests` error, preventing potential abuse such as DoS attacks and brute-force attempts.

This feature improves system stability, optimizes resource usage, and ensures fair API consumption.