### PR TITLE
feat: add data sanitization middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,8 @@ const morgan = require('morgan');
 // const exp = require('constants');
 const rateLimit = require('express-rate-limit');
 const helmet = require('helmet');
+const mongoSanitize = require('express-mongo-sanitize');
+const xss = require('xss-clean');
 
 const tourRouter = require('./routes/tourRoutes');
 const userRouter = require('./routes/userRoutes');
@@ -27,6 +29,13 @@ const limiter = rateLimit({
 });
 app.use('/api', limiter);
 app.use(express.json());
+
+// Data sanization against NoSql query injection
+app.use(mongoSanitize());
+
+// Data sanization against XSS
+app.use(xss());
+
 app.use(express.static(`${__dirname}/public`));
 
 app.use((req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "eslint-plugin-prettier": "^5.2.1",
         "eslint-plugin-react": "^7.37.2",
         "express": "^4.21.1",
+        "express-mongo-sanitize": "^2.2.0",
         "express-rate-limit": "^7.5.0",
         "helmet": "^8.0.0",
         "jsonwebtoken": "^9.0.2",
@@ -28,7 +29,8 @@
         "nodemailer": "^6.10.0",
         "prettier": "^3.3.3",
         "slugify": "^1.6.6",
-        "validator": "^13.12.0"
+        "validator": "^13.12.0",
+        "xss-clean": "^0.1.4"
       },
       "devDependencies": {
         "ndb": "^1.1.5"
@@ -1856,6 +1858,14 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-mongo-sanitize": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.2.0.tgz",
+      "integrity": "sha512-PZBs5nwhD6ek9ZuP+W2xmpvcrHwXZxD5GdieX2dsjPbAbH4azOkrHbycBud2QRU+YQF1CT+pki/lZGedHgo/dQ==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/express-rate-limit": {
@@ -5244,6 +5254,20 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/xss-clean": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/xss-clean/-/xss-clean-0.1.4.tgz",
+      "integrity": "sha512-4hArTFHYxrifK9VXOu/zFvwjTXVjKByPi6woUHb1IqxlX0Z4xtFBRjOhTKuYV/uE1VswbYsIh5vUEYp7MmoISQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dependencies": {
+        "xss-filters": "1.2.7"
+      }
+    },
+    "node_modules/xss-filters": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
+      "integrity": "sha512-KzcmYT/f+YzcYrYRqw6mXxd25BEZCxBQnf+uXTopQDIhrmiaLwO+f+yLsIvvNlPhYvgff8g3igqrBxYh9k8NbQ=="
     },
     "node_modules/xterm": {
       "version": "3.14.5",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-react": "^7.37.2",
     "express": "^4.21.1",
+    "express-mongo-sanitize": "^2.2.0",
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.0.0",
     "jsonwebtoken": "^9.0.2",
@@ -31,7 +32,8 @@
     "nodemailer": "^6.10.0",
     "prettier": "^3.3.3",
     "slugify": "^1.6.6",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "xss-clean": "^0.1.4"
   },
   "devDependencies": {
     "ndb": "^1.1.5"


### PR DESCRIPTION
Description:
This PR introduces two middleware for data sanitization:

express-mongo-sanitize: Prevents NoSQL query injection by filtering out $ and . operators.
xss-clean: Protects against cross-site scripting (XSS) attacks by sanitizing user input.
