### PR TITLE
refactor: implement handler factory for getOne and getAll controllers

### DIFF
--- a/controllers/handlerFactory.js
+++ b/controllers/handlerFactory.js
@@ -1,4 +1,5 @@
-const { catchAsync, AppError } = require('./../utils');
+const { populate } = require('../models/reviewModel');
+const { catchAsync, AppError, APIFeatures } = require('./../utils');
 exports.deleteOne = (Model) =>
   catchAsync(async (req, res, next) => {
     // controller logic
@@ -40,6 +41,47 @@ exports.createOne = (Model) =>
 
     res.status(201).json({
       status: 'success',
+      data: {
+        data: doc,
+      },
+    });
+  });
+
+exports.getOne = (Model, popOptions) =>
+  catchAsync(async (req, res, next) => {
+    // controller logic
+    let query = Model.findById(req.params.id);
+    if (popOptions) query = query.populate(popOptions);
+    const doc = await query;
+
+    if (!doc) {
+      return next(new AppError('No document found with that ID', 404));
+    }
+    res.status(200).json({
+      status: 'success',
+      data: {
+        data: doc,
+      },
+    });
+  });
+
+exports.getAll = (Model) =>
+  catchAsync(async (req, res, next) => {
+    // To allow for nested GET reviews on tour
+    let filter = {};
+    if (req.params.tourId) filter = { tour: req.params.tourId };
+
+    // EXECUTE QUERY
+    const features = new APIFeatures(Model.find(filter), req.query)
+      .filter()
+      .sort()
+      .limiting();
+    await features.pagination();
+    const doc = await features.query;
+
+    res.status(200).json({
+      status: 'success',
+      results: doc.length,
       data: {
         data: doc,
       },

--- a/controllers/reviewController.js
+++ b/controllers/reviewController.js
@@ -1,21 +1,6 @@
 const Review = require('../models/reviewModel');
-const { catchAsync } = require('./../utils');
+// const { catchAsync } = require('./../utils');
 const factory = require('./handlerFactory');
-
-exports.getAllReviews = catchAsync(async (req, res, next) => {
-  let filter = {};
-  if (req.params.tourId) filter = { tour: req.params.tourId };
-
-  const reviews = await Review.find(filter);
-
-  res.status(200).json({
-    status: 'success',
-    results: reviews.length,
-    data: {
-      reviews,
-    },
-  });
-});
 
 exports.setTourUserIds = (req, res, next) => {
   // Allow nested routes
@@ -24,6 +9,8 @@ exports.setTourUserIds = (req, res, next) => {
   next();
 };
 
+exports.getAllReviews = factory.getAll(Review);
+exports.getReview = factory.getOne(Review);
 exports.createReview = factory.createOne(Review);
 exports.updateReview = factory.updateOne(Review);
 exports.deleteReview = factory.deleteOne(Review);

--- a/controllers/tourController.js
+++ b/controllers/tourController.js
@@ -17,101 +17,10 @@ exports.aliasTopTours = (req, res, next) => {
   next();
 };
 
-exports.getAllTours = catchAsync(async (req, res, next) => {
-  console.log('tours knows authed user', req.user);
-  // NORMAL WAY
-  // const tours = await Tour.find({
-  //   duration: 5,
-  //   difficulty: 'easy',
-  // });
-
-  // const tours = await Tour.find()
-  //   .where('duration')
-  //   .equals(5)
-  //   .where('difficulty')
-  //   .equals('easy');
-
-  // {difficulty: "easy", duration: {$gte: 5}}
-
-  // 1A) FILTERING
-  // const queryObj = { ...req.query };
-  // const excludeFields = ['page', 'sort', 'limit', 'fields'];
-  // excludeFields.forEach((el) => delete queryObj[el]);
-
-  // // 2B) Advanced Filtering
-  // let queryStr = JSON.stringify(queryObj);
-  // queryStr = queryStr.replace(/\b(gte|gt|lte|lt)\b/g, (match) => `$${match}`);
-  // console.log(JSON.parse(queryStr));
-
-  // let query = Tour.find(JSON.parse(queryStr));
-
-  // // 2) Sorting
-  // if (req.query.sort) {
-  //   const sortBy = req.query.sort.replaceAll(',', ' ');
-  //   query = query.sort(sortBy);
-  // } else {
-  //   query = query.sort('-createdAt');
-  // }
-
-  // 3) Field limiting
-  // if (req.query.fields) {
-  //   const fields = req.query.fields.replaceAll(',', ' ');
-  //   query = query.select(fields);
-  // } else {
-  //   query = query.select('-__v');
-  // }
-
-  // 4) Pagination
-  // const page = Number(req.query.page) || 1;
-  // const page = req.query.page * 1 || 1;
-  // const limit = Number(req.query.limit) || 100;
-  // const skip = (page - 1) * limit;
-  // query = query.skip(skip).limit(limit);
-  // if (req.query.page) {
-  //   const numTours = await Tour.countDocuments();
-  //   if (skip >= numTours) {
-  //     throw new Error('This page does not exists');
-  //   }
-  // }
-
-  // EXECUTE QUERY
-  const features = new APIFeatures(Tour, req.query).filter().sort().limiting();
-  await features.pagination();
-  const tours = await features.query;
-
-  res.status(200).json({
-    status: 'success',
-    results: tours.length,
-    data: {
-      tours,
-    },
-  });
-});
+exports.getAllTours = factory.getAll(Tour);
 
 // Get Tour
-exports.getTour = catchAsync(async (req, res, next) => {
-  // validate inputs
-  // const id = req.params.id;
-  // const isValidId = mongoose.Types.ObjectId.isValid(id);
-  // if (!isValidId) throw new AppError('Id is not valid', 400);
-
-  validateId(req.params.id);
-
-  // controller logic
-  const tour = await Tour.findById(req.params.id).populate('reviews');
-
-  validateData(tour, 'Tour not found');
-
-  // validate output
-  // if (!tour) throw new AppError('Tour not found', 404);
-
-  res.status(200).json({
-    status: 'success',
-    data: {
-      tour,
-    },
-  });
-});
+exports.getTour = factory.getOne(Tour, { path: 'reviews' });
 
 // Create Tour
 exports.createTour = factory.createOne(Tour);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -13,57 +13,9 @@ const filterObj = (obj, ...allowedFields) => {
   return newObj;
 };
 
-exports.getAllUsers = async (req, res) => {
-  try {
-    const features = new APIFeatures(User, req.query)
-      .filter()
-      .sort()
-      .limiting();
-    await features.pagination();
-    const users = await features.query;
+exports.getAllUsers = factory.getAll(User);
 
-    res.status(200).json({
-      status: 'success',
-      results: users.length,
-      data: {
-        users,
-      },
-    });
-  } catch (err) {
-    // console.debug(err);
-    res.status(404).json({
-      status: 'fail',
-      message: err.message,
-    });
-  }
-};
-
-exports.getUser = async (req, res) => {
-  // res.status(500).json({
-  //   status: 'error',
-  //   message: 'This route is not defined',
-  // });
-  try {
-    const user = await User.findById(req.params.id);
-    if (!user) {
-      res.status(404).json({
-        status: 'fail',
-        message: 'no user found',
-      });
-    }
-    res.status(200).json({
-      status: 'success',
-      data: {
-        user,
-      },
-    });
-  } catch (err) {
-    res.status(404).json({
-      status: 'fail',
-      message: err,
-    });
-  }
-};
+exports.getUser = factory.getOne(User);
 
 exports.updateMe = catchAsync(async (req, res, next) => {
   // 1) Create error if user POSTs password data

--- a/routes/reviewRoutes.js
+++ b/routes/reviewRoutes.js
@@ -15,6 +15,7 @@ router
   );
 router
   .route('/:id')
+  .get(reviewController.getReview)
   .patch(reviewController.updateReview)
   .delete(reviewController.deleteReview);
 


### PR DESCRIPTION
This PR refactors the read operations (getOne, getAll) using a handler factory function.

By abstracting the logic into reusable functions, we:

Reduce code duplication across controllers

Make the codebase more maintainable and scalable

Allow optional population of related documents in getOne

This is part of an ongoing refactoring effort to generalize CRUD operations using factory functions.