### PR TITLE
feat: implement /me endpoint to retrieve current user's data

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -17,6 +17,11 @@ exports.getAllUsers = factory.getAll(User);
 
 exports.getUser = factory.getOne(User);
 
+exports.getMe = (req, res, next) => {
+  req.params.id = req.user.id;
+  next();
+};
+
 exports.updateMe = catchAsync(async (req, res, next) => {
   // 1) Create error if user POSTs password data
   if (req.body.password || req.body.passwordConfirm) {

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -23,7 +23,12 @@ userRouter.patch(
   authController.protect,
   authController.updatePassword,
 );
-
+userRouter.get(
+  '/me',
+  authController.protect,
+  userController.getMe,
+  userController.getUser,
+);
 userRouter.patch('/updateMe', authController.protect, userController.updateMe);
 userRouter.delete('/deleteMe', authController.protect, userController.deleteMe);
 


### PR DESCRIPTION
This PR adds a /me endpoint to the User API.

Instead of passing a user ID as a route parameter, this endpoint uses the currently authenticated user's ID (from the JWT) to fetch and return their own data.