### PR TITLE
feat: add index on price field to improve query performance

### DIFF
--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -109,6 +109,9 @@ const tourSchema = new mongoose.Schema(
   },
 );
 
+tourSchema.index({ price: 1 });
+tourSchema.index({ slug: 1 });
+
 tourSchema.virtual('durationWeeks').get(function () {
   return this.duration / 7;
 });


### PR DESCRIPTION
Added an index on the price field in the tours collection to optimize read performance.

This helps MongoDB avoid full collection scans when querying tours by price.

