### PR TITLE
feat: implement geospatial search for tours within a specified distance

### DIFF
--- a/controllers/tourController.js
+++ b/controllers/tourController.js
@@ -103,3 +103,31 @@ exports.getMonthlyPlan = catchAsync(async (req, res, next) => {
     },
   });
 });
+
+exports.getToursWithin = catchAsync(async (req, res, next) => {
+  const { distance, latlng, unit } = req.params;
+  const [lat, lng] = latlng.split(',');
+
+  const radius = unit === 'mi' ? distance / 3963.2 : distance / 6378.1;
+
+  if (!lat || !lng) {
+    next(
+      new AppError(
+        'Please provide latitutr and longitude in the format lat,lng',
+        400,
+      ),
+    );
+  }
+
+  const tours = await Tour.find({
+    startLocation: { $geoWithin: { $centerSphere: [[lng, lat], radius] } },
+  });
+
+  res.status(200).json({
+    stats: 'success',
+    result: tours.length,
+    data: {
+      data: tours,
+    },
+  });
+});

--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -111,6 +111,7 @@ const tourSchema = new mongoose.Schema(
 
 tourSchema.index({ price: 1 });
 tourSchema.index({ slug: 1 });
+tourSchema.index({ startLocation: '2dsphere' });
 
 tourSchema.virtual('durationWeeks').get(function () {
   return this.duration / 7;

--- a/routes/tourRoutes.js
+++ b/routes/tourRoutes.js
@@ -31,6 +31,10 @@ tourRouter
   );
 
 tourRouter
+  .route('/tours-within/:distance/center/:latlng/unit/:unit')
+  .get(tourController.getToursWithin);
+
+tourRouter
   .route('/')
   .get(tourController.getAllTours)
   .post(


### PR DESCRIPTION
Geospatial Search Feature
This PR introduces a new endpoint that allows users to search for tours starting within a specified distance from a given location.

Key Features:
New route: GET /tours-within/:distance/center/:latlng/unit/:unit

Parses and validates latitude, longitude, distance, and unit

Performs geospatial query using MongoDB’s $geoWithin and $centerSphere

Supports both kilometers and miles

This feature improves user experience by allowing location-based tour filtering.
