### PR TITLE
feat: calculate distances to all tours using geospatial aggregation

### DIFF
--- a/controllers/tourController.js
+++ b/controllers/tourController.js
@@ -131,3 +131,45 @@ exports.getToursWithin = catchAsync(async (req, res, next) => {
     },
   });
 });
+
+exports.getDistances = catchAsync(async (req, res, next) => {
+  const { latlng, unit } = req.params;
+  const [lat, lng] = latlng.split(',');
+
+  const multiplier = unit === 'mi' ? 0.000621371 : 0.001;
+
+  if (!lat || !lng) {
+    next(
+      new AppError(
+        'Please provide latitutr and longitude in the format lat,lng',
+        400,
+      ),
+    );
+  }
+
+  const distances = await Tour.aggregate([
+    {
+      $geoNear: {
+        near: {
+          type: 'Point',
+          coordinates: [lng * 1, lat * 1],
+        },
+        distanceField: 'distance',
+        distanceMultiplier: multiplier,
+      },
+    },
+    {
+      $project: {
+        distance: 1,
+        name: 1,
+      },
+    },
+  ]);
+
+  res.status(200).json({
+    status: 'success',
+    data: {
+      data: distances,
+    },
+  });
+});

--- a/models/tourModel.js
+++ b/models/tourModel.js
@@ -163,11 +163,11 @@ tourSchema.post(/^find/, function (docs, next) {
   next();
 });
 
-tourSchema.pre('aggregate', function (next) {
-  console.log(this.pipeline());
+// tourSchema.pre('aggregate', function (next) {
+//   console.log(this.pipeline());
 
-  next();
-});
+//   next();
+// });
 
 const Tour = mongoose.model('Tour', tourSchema);
 

--- a/routes/tourRoutes.js
+++ b/routes/tourRoutes.js
@@ -35,6 +35,10 @@ tourRouter
   .get(tourController.getToursWithin);
 
 tourRouter
+  .route('/distances/:latlng/unit/:unit')
+  .get(tourController.getDistances);
+
+tourRouter
   .route('/')
   .get(tourController.getAllTours)
   .post(


### PR DESCRIPTION
Added a new route to get distances from a specific location to all tours.
It uses MongoDB’s $geoNear to calculate the distance based on given coordinates (lat,lng) and supports km or mi units.